### PR TITLE
Allow TokenAuthentication subclasses

### DIFF
--- a/rest_registration/checks.py
+++ b/rest_registration/checks.py
@@ -96,7 +96,10 @@ def verification_from_check():
 def token_auth_config_check():
     return implies(
         registration_settings.LOGIN_RETRIEVE_TOKEN,
-        TokenAuthentication in api_settings.DEFAULT_AUTHENTICATION_CLASSES,
+        any(
+            issubclass(cls, TokenAuthentication),
+            for cls in api_settings.DEFAULT_AUTHENTICATION_CLASSES
+        )
     )
 
 

--- a/rest_registration/checks.py
+++ b/rest_registration/checks.py
@@ -97,7 +97,7 @@ def token_auth_config_check():
     return implies(
         registration_settings.LOGIN_RETRIEVE_TOKEN,
         any(
-            issubclass(cls, TokenAuthentication),
+            issubclass(cls, TokenAuthentication)
             for cls in api_settings.DEFAULT_AUTHENTICATION_CLASSES
         )
     )


### PR DESCRIPTION
Stop trigger of the check for TokenAuthentication if you have a TokenAuthentication subclass.

PS: lovely app, great for thrashing away AWS Cognito