### PR TITLE
Added DEFAULT_PERMISSION_CLASSES

### DIFF
--- a/rest_registration/api/views/login.py
+++ b/rest_registration/api/views/login.py
@@ -7,7 +7,7 @@ from rest_framework.authentication import (
 )
 from rest_framework.authtoken.models import Token
 from rest_framework.decorators import api_view, permission_classes
-from rest_framework.permissions import AllowAny, IsAuthenticated
+from rest_framework.permissions import IsAuthenticated
 from rest_framework.settings import api_settings
 
 from rest_registration.decorators import (
@@ -22,7 +22,7 @@ from rest_registration.utils.responses import get_ok_response
 @api_view_serializer_class_getter(
     lambda: registration_settings.LOGIN_SERIALIZER_CLASS)
 @api_view(['POST'])
-@permission_classes([AllowAny])
+@permission_classes(registration_settings.DEFAULT_PERMISSION_CLASSES)
 def login(request):
     '''
     Logs in the user via given login and password.

--- a/rest_registration/api/views/login.py
+++ b/rest_registration/api/views/login.py
@@ -22,7 +22,7 @@ from rest_registration.utils.responses import get_ok_response
 @api_view_serializer_class_getter(
     lambda: registration_settings.LOGIN_SERIALIZER_CLASS)
 @api_view(['POST'])
-@permission_classes(registration_settings.DEFAULT_PERMISSION_CLASSES)
+@permission_classes(registration_settings.NOT_AUTHENTICATED_PERMISSION_CLASSES)
 def login(request):
     '''
     Logs in the user via given login and password.

--- a/rest_registration/api/views/register.py
+++ b/rest_registration/api/views/register.py
@@ -3,7 +3,6 @@ from django.http import Http404
 from django.utils.translation import gettext as _
 from rest_framework import serializers, status
 from rest_framework.decorators import api_view, permission_classes
-from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 
 from rest_registration import signals
@@ -30,7 +29,7 @@ from rest_registration.utils.verification_notifications import (
 @api_view_serializer_class_getter(
     lambda: registration_settings.REGISTER_SERIALIZER_CLASS)
 @api_view(['POST'])
-@permission_classes([AllowAny])
+@permission_classes(registration_settings.DEFAULT_PERMISSION_CLASSES)
 def register(request):
     '''
     Register new user.
@@ -75,7 +74,7 @@ class VerifyRegistrationSerializer(serializers.Serializer):  # noqa: E501 pylint
 
 @api_view_serializer_class(VerifyRegistrationSerializer)
 @api_view(['POST'])
-@permission_classes([AllowAny])
+@permission_classes(registration_settings.DEFAULT_PERMISSION_CLASSES)
 def verify_registration(request):
     """
     Verify registration via signature.

--- a/rest_registration/api/views/register.py
+++ b/rest_registration/api/views/register.py
@@ -29,7 +29,7 @@ from rest_registration.utils.verification_notifications import (
 @api_view_serializer_class_getter(
     lambda: registration_settings.REGISTER_SERIALIZER_CLASS)
 @api_view(['POST'])
-@permission_classes(registration_settings.DEFAULT_PERMISSION_CLASSES)
+@permission_classes(registration_settings.NOT_AUTHENTICATED_PERMISSION_CLASSES)
 def register(request):
     '''
     Register new user.
@@ -74,7 +74,7 @@ class VerifyRegistrationSerializer(serializers.Serializer):  # noqa: E501 pylint
 
 @api_view_serializer_class(VerifyRegistrationSerializer)
 @api_view(['POST'])
-@permission_classes(registration_settings.DEFAULT_PERMISSION_CLASSES)
+@permission_classes(registration_settings.NOT_AUTHENTICATED_PERMISSION_CLASSES)
 def verify_registration(request):
     """
     Verify registration via signature.

--- a/rest_registration/api/views/register_email.py
+++ b/rest_registration/api/views/register_email.py
@@ -2,7 +2,7 @@ from django.http import Http404
 from django.utils.translation import gettext as _
 from rest_framework import serializers
 from rest_framework.decorators import api_view, permission_classes
-from rest_framework.permissions import AllowAny, IsAuthenticated
+from rest_framework.permissions import IsAuthenticated
 
 from rest_registration import signals
 from rest_registration.decorators import (
@@ -99,7 +99,7 @@ class VerifyEmailSerializer(serializers.Serializer):  # noqa: E501 pylint: disab
 
 @api_view_serializer_class(VerifyEmailSerializer)
 @api_view(['POST'])
-@permission_classes([AllowAny])
+@permission_classes(registration_settings.DEFAULT_PERMISSION_CLASSES)
 def verify_email(request):
     '''
     Verify email via signature.

--- a/rest_registration/api/views/register_email.py
+++ b/rest_registration/api/views/register_email.py
@@ -99,7 +99,7 @@ class VerifyEmailSerializer(serializers.Serializer):  # noqa: E501 pylint: disab
 
 @api_view_serializer_class(VerifyEmailSerializer)
 @api_view(['POST'])
-@permission_classes(registration_settings.DEFAULT_PERMISSION_CLASSES)
+@permission_classes(registration_settings.NOT_AUTHENTICATED_PERMISSION_CLASSES)
 def verify_email(request):
     '''
     Verify email via signature.

--- a/rest_registration/api/views/reset_password.py
+++ b/rest_registration/api/views/reset_password.py
@@ -54,7 +54,7 @@ class ResetPasswordSigner(URLParamsSigner):
 @api_view_serializer_class_getter(
     lambda: registration_settings.SEND_RESET_PASSWORD_LINK_SERIALIZER_CLASS)
 @api_view(['POST'])
-@permission_classes(registration_settings.DEFAULT_PERMISSION_CLASSES)
+@permission_classes(registration_settings.NOT_AUTHENTICATED_PERMISSION_CLASSES)
 def send_reset_password_link(request):
     '''
     Send email with reset password link.
@@ -100,7 +100,7 @@ class ResetPasswordSerializer(serializers.Serializer):  # noqa: E501 pylint: dis
 
 @api_view_serializer_class(ResetPasswordSerializer)
 @api_view(['POST'])
-@permission_classes(registration_settings.DEFAULT_PERMISSION_CLASSES)
+@permission_classes(registration_settings.NOT_AUTHENTICATED_PERMISSION_CLASSES)
 def reset_password(request):
     '''
     Reset password, given the signature and timestamp from the link.

--- a/rest_registration/api/views/reset_password.py
+++ b/rest_registration/api/views/reset_password.py
@@ -4,7 +4,6 @@ from django.http import Http404
 from django.utils.translation import gettext as _
 from rest_framework import serializers
 from rest_framework.decorators import api_view, permission_classes
-from rest_framework.permissions import AllowAny
 
 from rest_registration.decorators import (
     api_view_serializer_class,
@@ -55,7 +54,7 @@ class ResetPasswordSigner(URLParamsSigner):
 @api_view_serializer_class_getter(
     lambda: registration_settings.SEND_RESET_PASSWORD_LINK_SERIALIZER_CLASS)
 @api_view(['POST'])
-@permission_classes([AllowAny])
+@permission_classes(registration_settings.DEFAULT_PERMISSION_CLASSES)
 def send_reset_password_link(request):
     '''
     Send email with reset password link.
@@ -101,7 +100,7 @@ class ResetPasswordSerializer(serializers.Serializer):  # noqa: E501 pylint: dis
 
 @api_view_serializer_class(ResetPasswordSerializer)
 @api_view(['POST'])
-@permission_classes([AllowAny])
+@permission_classes(registration_settings.DEFAULT_PERMISSION_CLASSES)
 def reset_password(request):
     '''
     Reset password, given the signature and timestamp from the link.

--- a/rest_registration/settings_fields.py
+++ b/rest_registration/settings_fields.py
@@ -13,10 +13,10 @@ _Field = namedtuple('_Field', [
 class Field(_Field):
 
     def __new__(
-        cls, name, *,
-        default=None,
-        help=None,  # pylint: disable=redefined-builtin
-        import_string=False):
+            cls, name, *,
+            default=None,
+            help=None,  # pylint: disable=redefined-builtin
+            import_string=False):
         return super().__new__(
             cls, name=name, default=default,
             help=help, import_string=import_string)
@@ -316,10 +316,11 @@ MISC_SETTINGS_FIELDS = [
 PERMISSIONS_SETTINGS_FIELDS = [
     Field(
         'DEFAULT_PERMISSION_CLASSES',
-        default=['rest_framework.permissions.AllowAny',],
+        default=['rest_framework.permissions.AllowAny'],
         import_string=True,
         help=dedent("""\
-            This parameter establishes the permissions of the views that must be accessible without logging in.
+            This parameter establishes the permissions of the views that must
+            be accessible without logging in.
             Basically replace AllowAny with the specified class.
             Default: ``'rest_framework.permission.AllowAny'``
             """)

--- a/rest_registration/settings_fields.py
+++ b/rest_registration/settings_fields.py
@@ -13,10 +13,10 @@ _Field = namedtuple('_Field', [
 class Field(_Field):
 
     def __new__(
-            cls, name, *,
-            default=None,
-            help=None,  # pylint: disable=redefined-builtin
-            import_string=False):
+        cls, name, *,
+        default=None,
+        help=None,  # pylint: disable=redefined-builtin
+        import_string=False):
         return super().__new__(
             cls, name=name, default=default,
             help=help, import_string=import_string)
@@ -313,6 +313,19 @@ MISC_SETTINGS_FIELDS = [
     ),
 ]
 
+PERMISSIONS_SETTINGS_FIELDS = [
+    Field(
+        'DEFAULT_PERMISSION_CLASSES',
+        default=['rest_framework.permissions.AllowAny',],
+        import_string=True,
+        help=dedent("""\
+            This parameter establishes the permissions of the views that must be accessible without logging in.
+            Basically replace AllowAny with the specified class.
+            Default: ``'rest_framework.permission.AllowAny'``
+            """)
+    ),
+]
+
 SETTINGS_FIELDS_GROUPS_MAP = OrderedDict([
     ('user', USER_SETTINGS_FIELDS),
     ('register', REGISTER_SETTINGS_FIELDS),
@@ -323,8 +336,8 @@ SETTINGS_FIELDS_GROUPS_MAP = OrderedDict([
     ('change_password', CHANGE_PASSWORD_SETTINGS_FIELDS),
     ('profile', PROFILE_SETTINGS_FIELDS),
     ('misc', MISC_SETTINGS_FIELDS),
+    ('permissons', PERMISSIONS_SETTINGS_FIELDS),
 ])
-
 
 SETTINGS_FIELDS_GROUPS = list(SETTINGS_FIELDS_GROUPS_MAP.values())
 

--- a/rest_registration/settings_fields.py
+++ b/rest_registration/settings_fields.py
@@ -315,7 +315,7 @@ MISC_SETTINGS_FIELDS = [
 
 PERMISSIONS_SETTINGS_FIELDS = [
     Field(
-        'DEFAULT_PERMISSION_CLASSES',
+        'NOT_AUTHENTICATED_PERMISSION_CLASSES',
         default=['rest_framework.permissions.AllowAny'],
         import_string=True,
         help=dedent("""\


### PR DESCRIPTION
I have added a configuration to set the default permissions of the views that do not need to be logged-in.

Previously they were set to AllowAny which may not be desired in some cases, for example I use Oauth2 and I need to set the appropriate permissions limiting the use of the API to only my clients registered in Oautrh2 and not to any client.

The default setting is now AllowAny.

Changes: 
- Added DEFAULT_PERMISSION_CLASSES setting.


Please check and accept this PR or tell me if there is something wrong.