### PR TITLE
Prevent typing install in Python 3.6+

### DIFF
--- a/requirements/requirements-base.txt
+++ b/requirements/requirements-base.txt
@@ -1,3 +1,3 @@
 Django>=1.10
 djangorestframework>=3.3
-typing>=3.7,<3.8
+typing>=3.7,<3.8; python_version<'3.5'

--- a/requirements/requirements-linting.txt
+++ b/requirements/requirements-linting.txt
@@ -6,6 +6,6 @@ flake8-print
 flake8-tuple
 isort<5.0
 pylint
-mypy>=0.770,<0.780
+mypy
 django-stubs
-djangorestframework-stubs
+djangorestframework-stubs<1.3.0

--- a/rest_registration/checks.py
+++ b/rest_registration/checks.py
@@ -6,7 +6,6 @@ from django.contrib.auth import get_user_model
 from django.core.checks import register
 from django.core.exceptions import ImproperlyConfigured
 from django.db.models import Model
-from django.utils.module_loading import import_string
 from rest_framework.settings import api_settings
 
 from rest_registration.auth_token_managers import AbstractAuthTokenManager
@@ -115,7 +114,7 @@ def _is_auth_token_manager_auth_class_enabled() -> bool:
     auth_token_manager = _get_auth_token_manager()
     auth_cls = auth_token_manager.get_authentication_class()
     return any(
-        issubclass(import_string(cls), auth_cls)
+        issubclass(cls, auth_cls)
         for cls in api_settings.DEFAULT_AUTHENTICATION_CLASSES
     )
 

--- a/rest_registration/checks.py
+++ b/rest_registration/checks.py
@@ -6,6 +6,7 @@ from django.contrib.auth import get_user_model
 from django.core.checks import register
 from django.core.exceptions import ImproperlyConfigured
 from django.db.models import Model
+from django.utils.module_loading import import_string
 from rest_framework.settings import api_settings
 
 from rest_registration.auth_token_managers import AbstractAuthTokenManager
@@ -114,7 +115,7 @@ def _is_auth_token_manager_auth_class_enabled() -> bool:
     auth_token_manager = _get_auth_token_manager()
     auth_cls = auth_token_manager.get_authentication_class()
     return any(
-        issubclass(cls, auth_cls)
+        issubclass(import_string(cls), auth_cls)
         for cls in api_settings.DEFAULT_AUTHENTICATION_CLASSES
     )
 


### PR DESCRIPTION
### Checklist

*   [ ] I read [Contribution Guidelines](https://github.com/apragacz/django-rest-registration/blob/master/CONTRIBUTING.md#pull-requests)
*   [ ] I ran the checks and the tests (`make check && make test`) before submitting the PR on my branch and they passed
*   [ ] I attached unit tests testing the provided code so the code coverage will not drop below 98%

### Description

This change prevents pip from installing the `typing` backport package for python versions 3.6+ where the module is included in the standard library.

This is the officially recommended approach:
https://pypi.org/project/typing/

> For package maintainers, it is preferred to use `typing;python_version<"3.5"` if your package requires it to support earlier Python versions. This will avoid shadowing the stdlib typing module when your package is installed via `pip install -t .` on Python 3.5 or later.

### Why the change is needed?

In my case, docker builds are failing but the issue seems more widespread: https://github.com/python/typing/issues/573
