### PR TITLE
Limit CI jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,14 @@ cache:
     - "$HOME/virtualenv/python3.6.10"
 
 stages:
-  - check
-  - test
-  - tox-test
+  - name: check
+    if: (type = push AND branch = master) OR (type = pull_request AND NOT branch =~ /no-ci/)
+  - name: test
+    if: (type = push AND branch = master) OR (type = pull_request AND NOT branch =~ /no-ci/)
+  - name: tox-test-baseline
+    if: (type = push AND branch = master) OR (type = pull_request AND NOT branch =~ /no-ci/)
+  - name: tox-test
+    if: type = push AND branch = master
 
 jobs:
   fast_finish: true
@@ -45,26 +50,27 @@ jobs:
         - codecov
 
     - env: TOXENV=py37-django30
-      stage: tox-test
+      stage: tox-test-baseline
       python: "3.7"
+    - env: TOXENV=py37-django22
+      stage: tox-test-baseline
+      python: "3.7"
+    - env: TOXENV=py36-django21
+      stage: tox-test-baseline
+      python: "3.6"
+    - env: TOXENV=py36-django20
+      stage: tox-test-baseline
+      python: "3.6"
+
     - env: TOXENV=py36-django30
       stage: tox-test
       python: "3.6"
-    - env: TOXENV=py37-django22
-      stage: tox-test
-      python: "3.7"
     - env: TOXENV=py36-django22
-      stage: tox-test
-      python: "3.6"
-    - env: TOXENV=py36-django21
       stage: tox-test
       python: "3.6"
     - env: TOXENV=py35-django21
       stage: tox-test
       python: "3.5"
-    - env: TOXENV=py36-django20
-      stage: tox-test
-      python: "3.6"
     - env: TOXENV=py35-django20
       stage: tox-test
       python: "3.5"


### PR DESCRIPTION
### Checklist

*   [x] I read [Contribution Guidelines](https://github.com/apragacz/django-rest-registration/blob/master/CONTRIBUTING.md#pull-requests)
*   [x] I ran the checks and the tests (`make check && make test`) before submitting the PR on my branch and they passed
*   [x] I attached unit tests testing the provided code so the code coverage will not drop below 98%

### Description
Limit Travis CI jobs.

### Why the change is needed?
Limit CI jobs to limit Travis CI credits until transition is made to another CI platform.

