### PR TITLE
Update login.py

### DIFF
--- a/rest_registration/api/views/login.py
+++ b/rest_registration/api/views/login.py
@@ -94,7 +94,7 @@ def rest_auth_has_class(cls: type) -> bool:
 
 def perform_login(request: Request, user: 'AbstractBaseUser') -> Dict[str, Any]:
     if should_authenticate_session():
-        auth.login(request, user)
+        auth.login(request, user, backend='django.contrib.auth.backends.ModelBackend')
 
     extra_data = {}
 


### PR DESCRIPTION
### Checklist

*   [ ] I read [Contribution Guidelines](https://github.com/apragacz/django-rest-registration/blob/master/CONTRIBUTING.md#pull-requests)
*   [ ] I ran the checks and the tests (`make check && make test`) before submitting the PR on my branch and they passed
*   [ ] I attached unit tests testing the provided code so the code coverage will not drop below 98%

### Description
In case of multiple authentication backend (typically when combining this package with social django), one get an error on verification (of registration) with:
```
You have multiple authentication backends configured and therefore must 

provide the `backend` argument or set the `backend` attribute on the user.
```
This only occurs if we request to authenticate the session on login via
"LOGIN_AUTHENTICATE_SESSION"

### Why the change is needed?
The only change is to pass the default model backend as argument to avoid such failure.
A better solution (not tested) could be to add a setting to make the backend to use configurable

### Related issues, pull requests, links
Not applicable
