### PR TITLE
Feat/config mail send

### DIFF
--- a/rest_registration/api/views/register.py
+++ b/rest_registration/api/views/register.py
@@ -95,7 +95,9 @@ def process_verify_registration_data(input_data, serializer_context=None):
     serializer.is_valid(raise_exception=True)
 
     data = serializer.validated_data
-    signer = RegisterSigner(data)
+    # We use the signer only for verification, therefore we don't need a base_url and
+    # may set strict=False
+    signer = RegisterSigner(data, strict=False)
     verify_signer_or_bad_request(signer)
 
     verification_flag_field = get_user_setting('VERIFICATION_FLAG_FIELD')

--- a/rest_registration/api/views/register.py
+++ b/rest_registration/api/views/register.py
@@ -21,9 +21,6 @@ from rest_registration.utils.users import (
     get_user_setting
 )
 from rest_registration.utils.verification import verify_signer_or_bad_request
-from rest_registration.verification_notifications import (
-    send_register_verification_email_notification
-)
 
 
 @api_view_serializer_class_getter(
@@ -51,7 +48,8 @@ def register(request):
     with transaction.atomic():
         user = serializer.save(**kwargs)
         if registration_settings.REGISTER_VERIFICATION_ENABLED:
-            send_register_verification_email_notification(request, user)
+            email_sender = registration_settings.REGISTER_VERIFICATION_EMAIL_SENDER
+            email_sender(request, user)
 
     signals.user_registered.send(sender=None, user=user, request=request)
     output_serializer_class = registration_settings.REGISTER_OUTPUT_SERIALIZER_CLASS

--- a/rest_registration/api/views/register_email.py
+++ b/rest_registration/api/views/register_email.py
@@ -100,7 +100,9 @@ def process_verify_email_data(
     serializer.is_valid(raise_exception=True)
 
     data = serializer.validated_data
-    signer = RegisterEmailSigner(data)
+    # We use the signer only for verification, therefore we don't need a base_url and
+    # may set strict=False
+    signer = RegisterEmailSigner(data, strict=False)
     verify_signer_or_bad_request(signer)
     request = serializer_context.get('request')
     new_email = data['email']

--- a/rest_registration/api/views/register_email.py
+++ b/rest_registration/api/views/register_email.py
@@ -24,9 +24,6 @@ from rest_registration.utils.users import (
     user_with_email_exists
 )
 from rest_registration.utils.verification import verify_signer_or_bad_request
-from rest_registration.verification_notifications import (
-    send_register_email_verification_email_notification
-)
 
 
 @api_view_serializer_class_getter(
@@ -53,8 +50,8 @@ def register_email(request: Request) -> Response:
     email_already_used = is_user_email_field_unique() and user_with_email_exists(email)
 
     if registration_settings.REGISTER_EMAIL_VERIFICATION_ENABLED:
-        send_register_email_verification_email_notification(
-            request, user, email, email_already_used=email_already_used)
+        email_sender = registration_settings.REGISTER_EMAIL_VERIFICATION_EMAIL_SENDER
+        email_sender(request, user, email, email_already_used=email_already_used)
     else:
         if email_already_used:
             raise EmailAlreadyRegistered()

--- a/rest_registration/api/views/reset_password.py
+++ b/rest_registration/api/views/reset_password.py
@@ -19,9 +19,6 @@ from rest_registration.utils.validation import (
     validate_user_password_confirm
 )
 from rest_registration.utils.verification import verify_signer_or_bad_request
-from rest_registration.verification_notifications import (
-    send_reset_password_verification_email_notification
-)
 
 
 @api_view_serializer_class_getter(
@@ -48,7 +45,8 @@ def send_reset_password_link(request):
         if registration_settings.RESET_PASSWORD_FAIL_WHEN_USER_NOT_FOUND:
             raise
         return get_ok_response(success_message)
-    send_reset_password_verification_email_notification(request, user)
+    email_sender = registration_settings.RESET_PASSWORD_VERIFICATION_EMAIL_SENDER
+    email_sender(request, user)
     return get_ok_response(success_message)
 
 

--- a/rest_registration/api/views/reset_password.py
+++ b/rest_registration/api/views/reset_password.py
@@ -93,7 +93,9 @@ def process_reset_password_data(input_data, serializer_context=None):
     data = serializer.validated_data.copy()
     password = data.pop('password')
     data.pop('password_confirm', None)
-    signer = ResetPasswordSigner(data)
+    # We use the signer only for verification, therefore we don't need a base_url and
+    # may set strict=False
+    signer = ResetPasswordSigner(data, strict=False)
     verify_signer_or_bad_request(signer)
 
     user = get_user_by_verification_id(data['user_id'], require_verified=False)

--- a/rest_registration/checks.py
+++ b/rest_registration/checks.py
@@ -37,8 +37,11 @@ def auth_installed_check() -> bool:
     ErrorCode.NO_RESET_PASSWORD_VER_URL,
 )
 def reset_password_verification_url_check() -> bool:
+    sends_emails = (registration_settings.RESET_PASSWORD_VERIFICATION_ENABLED
+                    and registration_settings.is_default(
+                        'RESET_PASSWORD_VERIFICATION_EMAIL_SENDER'))
     return implies(
-        registration_settings.RESET_PASSWORD_VERIFICATION_ENABLED,
+        sends_emails,
         registration_settings.RESET_PASSWORD_VERIFICATION_URL,
     )
 
@@ -50,8 +53,11 @@ def reset_password_verification_url_check() -> bool:
     ErrorCode.NO_REGISTER_VER_URL,
 )
 def register_verification_url_check() -> bool:
+    sends_emails = (registration_settings.REGISTER_VERIFICATION_ENABLED
+                    and registration_settings.is_default(
+                        'REGISTER_VERIFICATION_EMAIL_SENDER'))
     return implies(
-        registration_settings.REGISTER_VERIFICATION_ENABLED,
+        sends_emails,
         registration_settings.REGISTER_VERIFICATION_URL,
     )
 
@@ -63,8 +69,11 @@ def register_verification_url_check() -> bool:
     ErrorCode.NO_REGISTER_EMAIL_VER_URL,
 )
 def register_email_verification_url_check() -> bool:
+    sends_emails = (registration_settings.REGISTER_EMAIL_VERIFICATION_ENABLED
+                    and registration_settings.is_default(
+                        'REGISTER_EMAIL_VERIFICATION_EMAIL_SENDER'))
     return implies(
-        registration_settings.REGISTER_EMAIL_VERIFICATION_ENABLED,
+        sends_emails,
         registration_settings.REGISTER_EMAIL_VERIFICATION_URL,
     )
 
@@ -75,12 +84,19 @@ def register_email_verification_url_check() -> bool:
     ErrorCode.NO_VER_FROM_EMAIL,
 )
 def verification_from_check() -> bool:
+    sends_emails = any([
+        registration_settings.REGISTER_VERIFICATION_ENABLED
+        and registration_settings.is_default(
+            'REGISTER_VERIFICATION_EMAIL_SENDER'),
+        registration_settings.REGISTER_EMAIL_VERIFICATION_ENABLED
+        and registration_settings.is_default(
+            'REGISTER_EMAIL_VERIFICATION_EMAIL_SENDER'),
+        registration_settings.RESET_PASSWORD_VERIFICATION_ENABLED
+        and registration_settings.is_default(
+            'RESET_PASSWORD_VERIFICATION_EMAIL_SENDER'),
+    ])
     return implies(
-        any([
-            registration_settings.REGISTER_VERIFICATION_ENABLED,
-            registration_settings.REGISTER_EMAIL_VERIFICATION_ENABLED,
-            registration_settings.RESET_PASSWORD_VERIFICATION_ENABLED,
-        ]),
+        sends_emails,
         registration_settings.VERIFICATION_FROM_EMAIL,
     )
 
@@ -156,8 +172,11 @@ def register_verification_one_time_auto_login_check() -> bool:
     ErrorCode.INVALID_EMAIL_TEMPLATE_CONFIG,
 )
 def valid_register_verification_email_template_config_check() -> None:
+    sends_emails = (registration_settings.REGISTER_VERIFICATION_ENABLED
+                    and registration_settings.is_default(
+                        'REGISTER_VERIFICATION_EMAIL_SENDER'))
     _validate_email_template_config(
-        registration_settings.REGISTER_VERIFICATION_ENABLED,
+        sends_emails,
         registration_settings.REGISTER_VERIFICATION_EMAIL_TEMPLATES,
     )
 
@@ -168,8 +187,11 @@ def valid_register_verification_email_template_config_check() -> None:
     ErrorCode.INVALID_EMAIL_TEMPLATE_CONFIG,
 )
 def valid_reset_password_verification_email_template_config_check() -> None:
+    sends_emails = (registration_settings.RESET_PASSWORD_VERIFICATION_ENABLED
+                    and registration_settings.is_default(
+                        'RESET_PASSWORD_VERIFICATION_EMAIL_SENDER'))
     _validate_email_template_config(
-        registration_settings.RESET_PASSWORD_VERIFICATION_ENABLED,
+        sends_emails,
         registration_settings.RESET_PASSWORD_VERIFICATION_EMAIL_TEMPLATES,
     )
 
@@ -180,8 +202,11 @@ def valid_reset_password_verification_email_template_config_check() -> None:
     ErrorCode.INVALID_EMAIL_TEMPLATE_CONFIG,
 )
 def valid_register_email_verification_email_template_config_check() -> None:
+    sends_emails = (registration_settings.REGISTER_EMAIL_VERIFICATION_ENABLED
+                    and registration_settings.is_default(
+                        'REGISTER_EMAIL_VERIFICATION_EMAIL_SENDER'))
     _validate_email_template_config(
-        registration_settings.REGISTER_EMAIL_VERIFICATION_ENABLED,
+        sends_emails,
         registration_settings.REGISTER_EMAIL_VERIFICATION_EMAIL_TEMPLATES,
     )
 

--- a/rest_registration/settings_fields.py
+++ b/rest_registration/settings_fields.py
@@ -116,6 +116,17 @@ REGISTER_SETTINGS_FIELDS = [
             """),
     ),
     Field(
+        'REGISTER_VERIFICATION_EMAIL_SENDER',
+        default='rest_registration.verification_notifications.send_register_verification_email_notification',  # noqa: E501
+        import_string=True,
+        help=dedent("""\
+            By default the email sender function will work with the build-in email
+            sending mechanism.
+
+            You can handle email sending all by yourself by overriding this setting.
+            """),
+    ),
+    Field(
         'REGISTER_VERIFICATION_PERIOD',
         default=datetime.timedelta(days=7),
         help=dedent("""\
@@ -275,6 +286,17 @@ RESET_PASSWORD_SETTINGS_FIELDS = [
     ),
     Field('RESET_PASSWORD_VERIFICATION_ENABLED', default=True),
     Field(
+        'RESET_PASSWORD_VERIFICATION_EMAIL_SENDER',
+        default='rest_registration.verification_notifications.send_reset_password_verification_email_notification',  # noqa: E501
+        import_string=True,
+        help=dedent("""\
+            By default the email sender function will work with the build-in email
+            sending mechanism.
+
+            You can handle email sending all by yourself by overriding this setting.
+            """),
+    ),
+    Field(
         'RESET_PASSWORD_VERIFICATION_PERIOD',
         default=datetime.timedelta(days=1),
     ),
@@ -316,6 +338,17 @@ REGISTER_EMAIL_SETTINGS_FIELDS = [
             """),
     ),
     Field('REGISTER_EMAIL_VERIFICATION_ENABLED', default=True),
+    Field(
+        'REGISTER_EMAIL_VERIFICATION_EMAIL_SENDER',
+        default='rest_registration.verification_notifications.send_register_email_verification_email_notification',  # noqa: E501
+        import_string=True,
+        help=dedent("""\
+            By default the email sender function will work with the build-in email
+            sending mechanism.
+
+            You can handle email sending all by yourself by overriding this setting.
+            """),
+    ),
     Field(
         'REGISTER_EMAIL_VERIFICATION_PERIOD',
         default=datetime.timedelta(days=7),

--- a/rest_registration/utils/nested_settings.py
+++ b/rest_registration/utils/nested_settings.py
@@ -36,6 +36,11 @@ class NestedSettings:
             if hasattr(self, key):
                 delattr(self, key)
 
+    def is_default(self, attr: str) -> bool:
+        if attr not in self.user_settings:
+            return True
+        return self.user_settings[attr] == self.defaults[attr]
+
     def __getattr__(self, attr: str) -> Any:
         if attr not in self.defaults.keys():
             raise AttributeError(


### PR DESCRIPTION
### Checklist

*   [x] I read [Contribution Guidelines](https://github.com/apragacz/django-rest-registration/blob/master/CONTRIBUTING.md#pull-requests)
*   [x] I ran the checks and the tests (`make check && make test`) before submitting the PR on my branch and they passed
*   [x] I attached unit tests testing the provided code so the code coverage will not drop below 98% (should be covered by existing tests)

### Description
The proposed changes make the email sending mechanism replaceable.

* Make the three email sending functions configurable (`*_EMAIL_SENDER` like `LOGIN_AUTHENTICATOR`).
* Adapt checks, if email sending is handled externally.
* Don't require verification signers to have a `BASE_URL` set.

### Why the change is needed?
Some apps send many emails and use their own mechanism for sending them. Of course, registration mails should be sent with the app's mechanism, so all of them can be treated the same way. Therefore one might want to replace email handling and just use the signers to pass the correct data with the emails.

### Related issues, pull requests, links
Email handling might be done in signal handlers (see #56). But nevertheless the email handling of `rest_registration` would have to be disabled in this case.
