### PR TITLE
Example fix for #259

### DIFF
--- a/rest_registration/utils/validation.py
+++ b/rest_registration/utils/validation.py
@@ -5,10 +5,12 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, List
 
 from django.contrib.auth.password_validation import validate_password
 from django.core.exceptions import ValidationError as DjangoValidationError
+from django.db import transaction
 from django.utils.translation import gettext as _
 from rest_framework.exceptions import ErrorDetail, ValidationError
 from rest_framework.settings import api_settings
 
+from rest_registration.settings import registration_settings
 from rest_registration.utils.users import (
     build_initial_user,
     get_user_by_verification_id
@@ -49,9 +51,12 @@ def validate_user_password_confirm(user_data: Dict[str, Any]) -> None:
 @wrap_validation_error_with_field('password')
 def validate_user_password(user_data: Dict[str, Any]) -> None:
     password = user_data['password']
-    user = build_initial_user(user_data)
-    return _validate_user_password(password, user)
 
+    with transaction.atomic():
+        user = registration_settings.REGISTER_SERIALIZER_CLASS().create(user_data)
+        result = _validate_user_password(password, user)
+        transaction.set_rollback(True)
+    return result
 
 @wrap_validation_error_with_field('password')
 def validate_password_with_user_id(user_data: Dict[str, Any]) -> None:


### PR DESCRIPTION
This pull request fixes #259, but may not be the best way to fix it. It just confirms the issue.

One observed drawback of this fix is that the register endpoint becomes very slow (takes a few seconds), but that requires further investigation to confirm.

To try this branch, use the similarly-named branch, [fix-nested-register-serializer](https://github.com/akhayyat/django-rest-registration-nested-register-serializer/tree/fix-nested-register-serializer), of the example Django project repository: [django-rest-registration-nested-register-serializer](https://github.com/akhayyat/django-rest-registration-nested-register-serializer).