### PR TITLE
Use UserAttrsProxy as last resort in build_initial_user (#259)

### DIFF
--- a/tests/unit_tests/api/views/register/test_register.py
+++ b/tests/unit_tests/api/views/register/test_register.py
@@ -91,7 +91,6 @@ def test_ok(
     assert_valid_register_verification_email(sent_email, user, timer)
 
 
-@pytest.mark.skip("TODO: Issue #259")
 @pytest.mark.django_db
 @override_rest_registration_settings({
     'REGISTER_SERIALIZER_CLASS': 'tests.testapps.custom_users.serializers.RegisterUserSerializer',  # noqa: E501


### PR DESCRIPTION
### Checklist

*   [x] I read [Contribution Guidelines](https://github.com/apragacz/django-rest-registration/blob/master/CONTRIBUTING.md#pull-requests)
*   [x] I ran the checks and the tests (`make check && make test`) before submitting the PR on my branch and they passed
*   [x] I attached unit tests testing the provided code so the code coverage will not drop below 98%

### Description
This change modifies `build_initial_user` which is required for password validation with the following logic:
1. Try to use the provided model with given attributes (previous behavior)
2. If that fails, because e.g. there is custom deserialization for nested elements then use `UserAttrsProxy` which will just pass the given attributes to validator function via "magic" object.

In most cases of password validation, we will only care about fields like `username` in that case, so the format of other fields will not affect that logic.

### Why the change is needed?
This change is required to solve #259.

### Related issues, pull requests, links
* #259 
