### PR TITLE
Description for REGISTER_VERIFICATION_ONE_TIME_USE

### DIFF
--- a/rest_registration/settings_fields.py
+++ b/rest_registration/settings_fields.py
@@ -186,7 +186,7 @@ REGISTER_SETTINGS_FIELDS = [
         default=False,
         help=dedent("""\
             This setting ensures the activation link can only be used once.
-            If REGISTER_VERIFICATION_AUTO_LOGIN is enabled, the link could auto-login 
+            If REGISTER_VERIFICATION_AUTO_LOGIN is enabled, the link could auto-login
             the user, which may not be desired.
             """),
     ),


### PR DESCRIPTION
Based on [this message](https://github.com/apragacz/django-rest-registration/issues/44#issuecomment-484851720)

### Checklist

*   [x] I read [Contribution Guidelines](https://github.com/apragacz/django-rest-registration/blob/master/CONTRIBUTING.md#pull-requests)
*   [ ] I ran the checks and the tests (`make check && make test`) before submitting the PR on my branch and they passed
*   [ ] I attached unit tests testing the provided code so the code coverage will not drop below 98%

Didn't run the checks as the commands don't work out of the box and can't spend too much time on this. Feel free to run them on your machine or discard the PR.

### Description
Add description to the `REGISTER_VERIFICATION_ONE_TIME_USE` setting, based on the maintainer's message linked above

### Why the change is needed?
Everyone loves documentation!
